### PR TITLE
fix(firebase): 빈 중복 초기화 시도 오류 해결

### DIFF
--- a/src/main/kotlin/org/bebefriends/infra/firebase/FirebaseConfiguration.kt
+++ b/src/main/kotlin/org/bebefriends/infra/firebase/FirebaseConfiguration.kt
@@ -9,22 +9,23 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class FirebaseConfiguration{
+class FirebaseConfiguration {
 
     @Bean
     fun firebaseApp(): FirebaseApp {
-        val options = FirebaseOptions.builder()
-            .setCredentials(GoogleCredentials.getApplicationDefault())
-            .build()
+        val options =
+            FirebaseOptions.builder().setCredentials(GoogleCredentials.getApplicationDefault())
+                .build()
         return FirebaseApp.initializeApp(options)
-    }
-    @Bean
-    fun firebaseAuth(): FirebaseAuth {
-        return FirebaseAuth.getInstance(firebaseApp())
     }
 
     @Bean
-    fun firebaseMessaging():FirebaseMessaging {
-        return FirebaseMessaging.getInstance(firebaseApp())
+    fun firebaseAuth(firebaseApp: FirebaseApp): FirebaseAuth {
+        return FirebaseAuth.getInstance(firebaseApp)
+    }
+
+    @Bean
+    fun firebaseMessaging(firebaseApp: FirebaseApp): FirebaseMessaging {
+        return FirebaseMessaging.getInstance(firebaseApp)
     }
 }


### PR DESCRIPTION
## 💡 이슈
- resolve #13 

## 🤩 개요
빈 초기화 시 빈 생성 메소드 호출을 통해 시도했으나
파이어베이스 앱 중복 초기화가 발생하여 주입 방식으로 변경

## 🧑‍💻 작업 사항
작업한 내용을 적어주세요.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.