### PR TITLE
fix(firebase): 빈 초기화 문제 해결

### DIFF
--- a/src/main/kotlin/org/bebefriends/infra/firebase/FirebaseConfiguration.kt
+++ b/src/main/kotlin/org/bebefriends/infra/firebase/FirebaseConfiguration.kt
@@ -16,7 +16,11 @@ class FirebaseConfiguration {
         val options =
             FirebaseOptions.builder().setCredentials(GoogleCredentials.getApplicationDefault())
                 .build()
-        return FirebaseApp.initializeApp(options)
+        return if (isExists()) FirebaseApp.getInstance() else FirebaseApp.initializeApp(options)
+    }
+
+    private fun isExists(): Boolean {
+        return FirebaseApp.getApps() != null && FirebaseApp.getApps().isNotEmpty()
     }
 
     @Bean


### PR DESCRIPTION
## 💡 이슈
- resolve #17 

## 🤩 개요
서버 실행 시 파이어베이스 앱 중복 초기화 예외발생

## 🧑‍💻 작업 사항
파이어베이스는 동일 앱 SDK를 하나만 초기화할 수 있으나
연관 빈을 초기화 하는 과정에서 해당메소드가 재호출되어 조건문으로 해결

## 📖 참고 사항
- https://stackoverflow.com/questions/37787330/java-ee-firebaseapp-name-default-already-exists